### PR TITLE
fix(widgets): use standard way to include static assests

### DIFF
--- a/versatileimagefield/widgets.py
+++ b/versatileimagefield/widgets.py
@@ -4,7 +4,6 @@ from django.forms.widgets import (
     CheckboxInput, ClearableFileInput,
     HiddenInput, MultiWidget, Select
 )
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.encoding import force_text
 from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
@@ -185,17 +184,9 @@ class VersatileImagePPOIClickWidget(SizedImageCenterpointWidgetMixIn,
 
     class Media:
         css = {
-            'all': (
-                staticfiles_storage.url(
-                    'versatileimagefield/css/versatileimagefield.css'
-                ),
-            ),
+            'all': ('versatileimagefield/css/versatileimagefield.css',),
         }
-        js = (
-            staticfiles_storage.url(
-                'versatileimagefield/js/versatileimagefield.js'
-            ),
-        )
+        js = ('versatileimagefield/js/versatileimagefield.js',)
 
     def render(self, name, value, attrs=None):
         rendered = super(VersatileImagePPOIClickWidget, self).render(
@@ -213,12 +204,7 @@ class SizedImageCenterpointClickDjangoAdminWidget(
 
     class Media:
         css = {
-            'all': (
-                staticfiles_storage.url(
-                    'versatileimagefield/css/versatileimagefield-'
-                    'djangoadmin.css'
-                ),
-            ),
+            'all': ('versatileimagefield/css/versatileimagefield-djangoadmin.css',),
         }
 
 
@@ -256,10 +242,5 @@ class SizedImageCenterpointClickBootstrap3Widget(
 
     class Media:
         css = {
-            'all': (
-                staticfiles_storage.url(
-                    'versatileimagefield/css/versatileimagefield-'
-                    'bootstrap3.css'
-                ),
-            ),
+            'all': ('versatileimagefield/css/versatileimagefield-bootstrap3.css',),
         }


### PR DESCRIPTION
While using `ManifestStaticFilesStorage` there seems to be some issues around use of `staticfilestore.url` in `widgets.py` while running `collectstatic` command.

It raises the following `ValueError`:
```
ValueError: The file 'versatileimagefield/css/versatileimagefield.css' could not be found with <whitenoise.django.GzipManifestStaticFilesStorage
```

This issue is not seen with other widgets that use normal method of including Form Assets[1]. Things works fine, after this change:

<img width="910" alt="1___users_theskumar_work_exp_hello-world-web__zsh_" src="https://cloud.githubusercontent.com/assets/236356/11659073/558be2fc-9dec-11e5-94fd-162877730a05.png">

[1] https://docs.djangoproject.com/en/1.9/topics/forms/media/#assets-as-a-static-definition