### PR TITLE
Overload _get_url to return placeholder.

### DIFF
--- a/versatileimagefield/mixins.py
+++ b/versatileimagefield/mixins.py
@@ -32,6 +32,12 @@ class VersatileImageMixIn(object):
         else:
             self.ppoi = (0.5, 0.5)
 
+    def _get_url(self):
+        if not self.name and self.field.placeholder_image_name:
+            return self.storage.url(self.field.placeholder_image_name)
+        return super(VersatileImageMixIn, self)._get_url()
+    url = property(_get_url)
+
     @property
     def create_on_demand(self):
         return self._create_on_demand


### PR DESCRIPTION
Fixes #30. Though it might be better to just set self.name to the placeholder if no image is present. Then the other functions from FileField like `_get_path`, `_get_file` and `_get_size` would also work. Then things like [`if not self.name`](https://github.com/jelko/django-versatileimagefield/blob/da94966fd842b276067d170741cdee09e6231af6/versatileimagefield/mixins.py#L71) need to be refactored to check if the image originally was not set though.