### PR TITLE
Adds ICC profile preservation in preprocess_image

### DIFF
--- a/versatileimagefield/datastructures/base.py
+++ b/versatileimagefield/datastructures/base.py
@@ -84,7 +84,7 @@ class ProcessedImage(object):
                     image = image.transpose(Image.ROTATE_270)
                 elif orientation == 8:
                     image = image.transpose(Image.ROTATE_90)
-        
+
         # Ensure any embedded ICC profile is preserved
         save_kwargs['icc_profile'] = image.info.get('icc_profile')
 

--- a/versatileimagefield/datastructures/base.py
+++ b/versatileimagefield/datastructures/base.py
@@ -84,6 +84,9 @@ class ProcessedImage(object):
                     image = image.transpose(Image.ROTATE_270)
                 elif orientation == 8:
                     image = image.transpose(Image.ROTATE_90)
+        
+        # Ensure any embedded ICC profile is preserved
+        save_kwargs['icc_profile'] = image.info.get('icc_profile')
 
         if hasattr(self, 'preprocess_%s' % image_format):
             image, addl_save_kwargs = getattr(


### PR DESCRIPTION
Just like EXIF data, some formats (JPEG at least) can also contain an embedded ICC profile, so this PR makes sure it's carried along in any processed versions. It has no effect when there's no ICC profile embedded.